### PR TITLE
fix copy link notification 

### DIFF
--- a/src/components/Notification/styles.module.scss
+++ b/src/components/Notification/styles.module.scss
@@ -1,6 +1,7 @@
 @import "../../styles/Variables.module.scss";
 
 .notification {
+  transform: translate(0%, -110%);
   width: max-content !important;
   height: max-content;
   background-color: $black;
@@ -12,7 +13,7 @@
 #notificationslide {
   position: absolute;
   top: 0px;
-  right: 0px;
+  right: -20px;
 
   -webkit-animation: notificationslide 0.7s forwards;
   animation: notificationslide 0.7s forwards;
@@ -20,12 +21,12 @@
 
 @-webkit-keyframes notificationslide {
   100% {
-    right: 45px;
+    right: 0px;
   }
 }
 
 @keyframes notificationslide {
   100% {
-    right: 45px;
+    right: 0px;
   }
 }

--- a/src/components/ShareSocialCta/Styles.module.scss
+++ b/src/components/ShareSocialCta/Styles.module.scss
@@ -85,6 +85,7 @@
 }
 
 .socialBlock {
+  position: relative;
   text-align: center;
   display: block !important;
   border: 1px solid #008f50;

--- a/src/components/ShareSocialCta/index.js
+++ b/src/components/ShareSocialCta/index.js
@@ -21,8 +21,6 @@ function ShareSocialCta({
   facebookHashtag,
   linkedinTitle,
   linkedinDescription,
-  socialTitle,
-  socialCopy,
   twitterTitle,
   twitterAccount,
   twitterHashtags,


### PR DESCRIPTION
The notification for the copy link button was appearing outside of the viewport. This PR fixes that and you can see how it now renders in this gif: 

![Screencast 2019-05-29 at 10 16 24 pm (1)](https://user-images.githubusercontent.com/26777813/58592062-97b16480-825f-11e9-8943-b1971bff341b.gif)
