### PR TITLE
Strip hash from ‘Copy link’ share CTA

### DIFF
--- a/src/components/SocialButtons/CopyLinkButton.js
+++ b/src/components/SocialButtons/CopyLinkButton.js
@@ -9,8 +9,8 @@ export default function CopyLinkButton(props) {
 
   function copyLink() {
     const input = document.createElement("input");
-    const text = props.currentUrl;
-
+    const currentUrl = props.currentUrl;
+    const text = currentUrl.split("#")[0];
     document.body.appendChild(input);
     input.value = text;
 


### PR DESCRIPTION
## Done

Strip hash from ‘Copy link’ share CTA on homepage

## QA

- Pull feature branch
- Run `gatsby develop`
- View http://localhost:8000/
- Click 'Share this page' in CTA on bottom right of screen
- Click 'Copy link'
- Paste into text file and verify URL no longer contains a hash

Fixes #82