### PR TITLE
WIP: Set explicit height to prevent reflow on tablet

### DIFF
--- a/src/components/HomeIntro/Styles.module.scss
+++ b/src/components/HomeIntro/Styles.module.scss
@@ -46,6 +46,7 @@
   }
   @include mq("tablet") {
     text-align: left;
+    height: 200px;
   }
 }
 


### PR DESCRIPTION
Was previously causing div to change size as the TypistLoop ran.

Fixes #116 