### PR TITLE
Made share link scroll smoothly.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react": "^16.8.2",
     "react-dom": "^16.8.2",
     "react-helmet": "^5.2.0",
+    "react-scroll": "^1.7.12",
     "react-share": "^2.4.0",
     "react-typist": "^2.0.5",
     "react-typist-loop": "^0.0.5",

--- a/src/components/EarthyShare/Styles.module.scss
+++ b/src/components/EarthyShare/Styles.module.scss
@@ -42,10 +42,6 @@
   line-height: 16px;
 }
 
-.bubbleLink {
-  @include no-underline;
-}
-
 .bubbleTick {
   position: absolute;
   top: 80px;

--- a/src/components/EarthyShare/index.js
+++ b/src/components/EarthyShare/index.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { Link, Events } from "react-scroll";
 import GlobalStyles from "../../styles/Global.module.scss";
 import ButtonStyles from "../../styles/Buttons.module.scss";
 import Styles from "./Styles.module.scss";
@@ -7,16 +8,25 @@ import Tick from "./BubbleTick.svg";
 
 const EarthyShare = () => {
   const [show, setShow] = useState(false);
+  const [wasShown, setWasShown] = useState(false);
 
-  let handleScroll = () => {
-    if (window.scrollY > 0) {
+  let handleWindowScroll = () => {
+    if (!wasShown && window.scrollY > 0) {
       setShow(true);
+      setWasShown(true);
     }
   };
 
+  let handleSmoothScrollEnd = () => setShow(false);
+
   useEffect(() => {
-    window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
+    window.addEventListener("scroll", handleWindowScroll);
+    return () => window.removeEventListener("scroll", handleWindowScroll);
+  });
+
+  useEffect(() => {
+    Events.scrollEvent.register("end", handleSmoothScrollEnd);
+    return () => Events.scrollEvent.remove("end");
   });
 
   return (
@@ -32,19 +42,19 @@ const EarthyShare = () => {
           </span>{" "}
           Share this page
         </span>
-        <a
-          className={Styles.bubbleLink}
-          href="#share"
+
+        <Link
+          to="share"
+          smooth={"easeInOutQuad"}
+          duration={500}
           title="See how you can take action"
+          href="#share"
+          className={`${ButtonStyles.btnSimple} ${ButtonStyles.btnXs} ${
+            ButtonStyles.btnPrimary
+          } ${ButtonStyles.btnEarthyShare} `}
         >
-          <button
-            className={`${ButtonStyles.btnSimple} ${ButtonStyles.btnXs} ${
-              ButtonStyles.btnPrimary
-            } ${ButtonStyles.btnEarthyShare} `}
-          >
-            Share
-          </button>
-        </a>
+          Share
+        </Link>
         <img src={Tick} alt="Bubble" className={Styles.bubbleTick} />
       </div>
       <div className={Styles.icon}>

--- a/src/components/ShareSocialCta/index.js
+++ b/src/components/ShareSocialCta/index.js
@@ -29,10 +29,7 @@ function ShareSocialCta({
   currentUrl
 }) {
   return (
-    <section className={styles.container}>
-      <a id="share" aria-label={"Share"}>
-        {null}
-      </a>
+    <section id="share" aria-label="share" className={styles.container}>
       <div className={`${GlobalStyles.inner} ${styles.inner}`}>
         {/* cta block / right col */}
         <div className={styles.ctaCopy}>

--- a/src/styles/Buttons.module.scss
+++ b/src/styles/Buttons.module.scss
@@ -456,6 +456,6 @@
 
 .btn-earthy-share {
   padding: 5px 0 !important;
-  width: 100%;
   font-size: 13px !important;
+  @include no-underline;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8191,6 +8191,11 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
+
 lodash.toarray@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
@@ -11231,6 +11236,14 @@ react-scroll-sync@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/react-scroll-sync/-/react-scroll-sync-0.6.0.tgz#c87eba2cdd55ae35874277d74b034419d73df59a"
   integrity sha512-Frc7pNPIEQY6rUAUwm1wW0an57Xau6X1Sag+Ra2FJT+oDBEBdh4cahrE3oGwtYHPcyWMt74q7vRKLw73cPy6aw==
+
+react-scroll@^1.7.12:
+  version "1.7.12"
+  resolved "https://registry.yarnpkg.com/react-scroll/-/react-scroll-1.7.12.tgz#6bd453d04ec70e03bebe04d8b43b5d91e3d776cc"
+  integrity sha512-hvi3MixtYQC1FADODqWx6MSYaShBbsq7ElQBny/pmzrGtF4ubGLuDOGpzP3mvJjWZ66Cepujt4PBjysYV3itwg==
+  dependencies:
+    lodash.throttle "^4.1.1"
+    prop-types "^15.5.8"
 
 react-select@^2.4.2:
   version "2.4.3"


### PR DESCRIPTION
- uses `react-scroll` npm module, which imports `lodash.throttle`
- after click, icon disappears and won't come back
  - because you've already clicked it and now you know there's a share section on the page you can scroll to
  - it will come back on other pages
- I changed the `ShareSocialCta` markup so that we scroll to the top of the section, not the top of the earth icon
  - because looks better to have white space at the top of the window
  - I believe `aria-label` works on `section` elements as well as anchors, but I am not an accessibility expert

Demo GIF:

![2019-08-10 at 5 25 PM](https://user-images.githubusercontent.com/8683/62827429-27468e00-bb94-11e9-8fcf-2b1203114eb8.gif)
