### PR TITLE
Add eslint a11y plugin to pre-commit git hook

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,8 @@
 module.exports = {
-  extends: [
-    'eslint:recommended'
-  ],
+  extends: ["eslint:recommended", "plugin:jsx-a11y/recommended"],
   settings: {
     react: {
-      version: 'detect'
+      version: "detect"
     }
   },
   env: {
@@ -18,13 +16,13 @@ module.exports = {
       jsx: true
     },
     ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
-    sourceType: 'module' // Allows for the use of imports
+    sourceType: "module" // Allows for the use of imports
   },
   overrides: [
     {
-      files: ['*.js'],
+      files: ["*.js"],
       rules: {
-        'no-unused-vars': ['off', "error", {"varsIgnorePattern": "_"}] // Allows for use of '_' as a not-needed variable.
+        "no-unused-vars": ["off", "error", { varsIgnorePattern: "_" }] // Allows for use of '_' as a not-needed variable.
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged"
+      "pre-commit": "pretty-quick --staged && eslint src"
     }
   }
 }


### PR DESCRIPTION
Now we are ensured that all commits pass a11y's accessibility checks. Not WAVE exactly, but it's similar enough I think.

- Set up eslint to check `eslint-plugin-jsx-a11y` rules during lint
- Run eslint on `src/` in pre-commit git hook
- Didn't fix all the problems that a11y found the first time

Addresses Issue #121 