### PR TITLE
Add more detail about set-up to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ git@github.com:impactmakers/climatechoice.git
 cd climatechoice
 ```
 
-Then install dependencies
+Then install dependencies using [yarn](https://yarnpkg.com/en/docs/install)
 
 ```bash
 yarn install
@@ -26,6 +26,8 @@ Start the development server and visit http://localhost:8000/
 ```bash
 gatsby develop
 ```
+
+If you've not used Gatsby before, you might need to [install the Gatsby CLI](https://www.gatsbyjs.org/tutorial/part-zero/) first.
 
 &nbsp;
 


### PR DESCRIPTION
When I was going through and setting this up locally, I didn't have yarn or Gatsby CLI set up. I had a google around and found how to install them. I figured I might as well put those links into the README, in case they're useful for someone else :)

