### PR TITLE
Add support for Web Share API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ Then install dependencies
 yarn install
 ```
 
-If you have not used Gatsby before, make sure to [install the Gatsby CLI globally](https://github.com/gatsbyjs/gatsby#-get-up-and-running-in-5-minutes).
-
 ## Running
 
 Start the development server and visit http://localhost:8000/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Then install dependencies
 yarn install
 ```
 
+If you have not used Gatsby before, make sure to [install the Gatsby CLI globally](https://github.com/gatsbyjs/gatsby#-get-up-and-running-in-5-minutes).
+
 ## Running
 
 Start the development server and visit http://localhost:8000/

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
+    "checkJs": true,
     "module": "esnext",
-    "target": "es2019"
-  }
+    "target": "es2019",
+    "moduleResolution": "node",
+    "jsx": "react"
+  },
+  "exclude": ["node_modules", "**/node_modules/*"]
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "es2019"
+  }
+}

--- a/src/components/ShareSocialCta/index.js
+++ b/src/components/ShareSocialCta/index.js
@@ -90,7 +90,7 @@ function ShareSocialCta({
   whatsappTitle,
   currentUrl
 }) {
-  const webShareApi = "share" in navigator;
+  const webShareApi = "share" in window.navigator;
   const propsForFallbackShareButtons = {
     ctaTitle,
     emailBody,

--- a/src/components/ShareSocialCta/index.js
+++ b/src/components/ShareSocialCta/index.js
@@ -90,7 +90,8 @@ function ShareSocialCta({
   whatsappTitle,
   currentUrl
 }) {
-  const webShareApi = "share" in window.navigator;
+  const webShareApi =
+    typeof window !== "undefined" && "share" in window.navigator;
   const propsForFallbackShareButtons = {
     ctaTitle,
     emailBody,

--- a/src/components/ShareSocialCta/index.js
+++ b/src/components/ShareSocialCta/index.js
@@ -9,7 +9,69 @@ import TwitterButton from "../SocialButtons/TwitterButton";
 import FacebookButton from "../SocialButtons/FacebookButton";
 import WhatsappButton from "../SocialButtons/WhatsappButton";
 import LinkedinButton from "../SocialButtons/LinkedInButton";
+import NativeShareButton from "../SocialButtons/NativeShareButton";
 import EarthIcon from "../Images/Icons/EarthIcon.svg";
+
+function FallbackShareButtons({
+  ctaTitle,
+  emailBody,
+  emailSubject,
+  facebookQuote,
+  facebookHashtag,
+  linkedinTitle,
+  linkedinDescription,
+  twitterTitle,
+  twitterAccount,
+  twitterHashtags,
+  url,
+  whatsappTitle,
+  currentUrl
+}) {
+  return (
+    <div className={styles.socialContainer}>
+      <div className={styles.socialButton}>
+        <TwitterButton
+          url={url}
+          currentUrl={currentUrl}
+          twitterTitle={twitterTitle}
+          twitterAccount={twitterAccount}
+          hashtags={twitterHashtags}
+        />
+      </div>
+      <div className={styles.socialButton}>
+        <FacebookButton
+          url={url}
+          currentUrl={currentUrl}
+          facebookQuote={facebookQuote}
+          facebookHashtag={facebookHashtag}
+        >
+          {null}
+        </FacebookButton>
+      </div>
+      <div className={styles.socialButton}>
+        <WhatsappButton url={url} whatsappTitle={whatsappTitle} />
+      </div>
+      <div className={styles.socialButton}>
+        <LinkedinButton
+          url={url}
+          currentUrl={currentUrl}
+          title={linkedinTitle}
+          description={linkedinDescription}
+        />
+      </div>
+      <div className={styles.socialButton}>
+        <EmailButton
+          emailBody={emailBody}
+          currentUrl={currentUrl}
+          emailSubject={emailSubject}
+        />
+      </div>
+      <div className={styles.socialButton}>
+        <CopyLinkButton currentUrl={currentUrl} />
+      </div>
+    </div>
+  );
+}
 
 function ShareSocialCta({
   children,
@@ -28,6 +90,29 @@ function ShareSocialCta({
   whatsappTitle,
   currentUrl
 }) {
+  const webShareApi = "share" in navigator;
+  const propsForFallbackShareButtons = {
+    ctaTitle,
+    emailBody,
+    emailSubject,
+    facebookQuote,
+    facebookHashtag,
+    linkedinTitle,
+    linkedinDescription,
+    twitterTitle,
+    twitterAccount,
+    twitterHashtags,
+    url,
+    whatsappTitle,
+    currentUrl
+  };
+
+  const shareButtons = webShareApi ? (
+    <NativeShareButton title="Climate Choice" text={twitterTitle} url={url} />
+  ) : (
+    <FallbackShareButtons {...propsForFallbackShareButtons} />
+  );
+
   return (
     <section id="share" aria-label="share" className={styles.container}>
       <div className={`${GlobalStyles.inner} ${styles.inner}`}>
@@ -51,50 +136,9 @@ function ShareSocialCta({
               Send this page to your friends, family and followers via our handy
               pre written message.
             </p>
-
-            <div className={styles.socialContainer}>
-              <div className={styles.socialButton}>
-                <TwitterButton
-                  url={url}
-                  currentUrl={currentUrl}
-                  twitterTitle={twitterTitle}
-                  twitterAccount={twitterAccount}
-                  hashtags={twitterHashtags}
-                />
-              </div>
-              <div className={styles.socialButton}>
-                <FacebookButton
-                  url={url}
-                  currentUrl={currentUrl}
-                  facebookQuote={facebookQuote}
-                  facebookHashtag={facebookHashtag}
-                >
-                  {null}
-                </FacebookButton>
-              </div>
-              <div className={styles.socialButton}>
-                <WhatsappButton url={url} whatsappTitle={whatsappTitle} />
-              </div>
-              <div className={styles.socialButton}>
-                <LinkedinButton
-                  url={url}
-                  currentUrl={currentUrl}
-                  title={linkedinTitle}
-                  description={linkedinDescription}
-                />
-              </div>
-              <div className={styles.socialButton}>
-                <EmailButton
-                  emailBody={emailBody}
-                  currentUrl={currentUrl}
-                  emailSubject={emailSubject}
-                />
-              </div>
-              <div className={styles.socialButton}>
-                <CopyLinkButton currentUrl={currentUrl} />
-              </div>
-            </div>
+            {shareButtons}
           </div>
+
           <span className={styles.thanks}>
             Thank you{" "}
             <span role="img" aria-label="raising_hands">

--- a/src/components/SocialButtons/NativeShareButton.js
+++ b/src/components/SocialButtons/NativeShareButton.js
@@ -1,0 +1,44 @@
+import React from "react";
+import styles from "./styles.module.scss";
+import buttonStyles from "../../styles/Buttons.module.scss";
+
+/**
+ * @typedef Props
+ * @prop {string} title
+ * @prop {string} text
+ * @prop {string} url
+ */
+
+/**
+ * Renders a button that opens the Web Share API dialog
+ * with the, in Props, provided text, title and url.
+ *
+ * @param {Props} props
+ */
+export default function NativeShareButton(props) {
+  const { title, text, url } = props;
+
+  async function openShareDialog() {
+    try {
+      await navigator.share({
+        title,
+        text,
+        url
+      });
+    } catch (shareError) {
+      // Handle share error maybe?
+      // This would be trying to share on unsecure origins...
+    }
+  }
+
+  return (
+    <>
+      <button
+        className={`${styles.button} ${buttonStyles.btnSimple}`}
+        onClick={openShareDialog}
+      >
+        Share
+      </button>
+    </>
+  );
+}


### PR DESCRIPTION
This enables [platforms that support Web Share API](https://caniuse.com/#search=web%20share), like Android, to share to all apps that allow being shared to. Just like if you were sharing from a native app.

See video here for example of sharing to Slack with this change: https://youtu.be/Ewmu4FVcF4A